### PR TITLE
bump python version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.7'
+          python-version: '3.11'
 
       - name: Install MDI Mechanic
         run: |


### PR DESCRIPTION
CI is failing because of a compatibility mismatch between Python version required by MDI Mechanic and Python version in CI environment. I think this will fix the problem.